### PR TITLE
BugzID: 4130 - Add CGI.unescapeHTML for email message share url

### DIFF
--- a/app/views/rad_social_mailer/social_mail_form.html.haml
+++ b/app/views/rad_social_mailer/social_mail_form.html.haml
@@ -29,7 +29,7 @@
       Message
     %div.form-fields
       %textarea{:class => "input-textbox", :id => "rs-message", :name => "message", :rows => 5, :cols => 40}
-        = email_message
+        = CGI.unescapeHTML(email_message)
   %input{:type=>"hidden", :name=>"subject", :value=> email_subject}
   %input{:type=>"hidden", :id=>"rs-base-message", :value=> email_message}
   #recaptcha-container.captcha-container


### PR DESCRIPTION
Tried to escape this from cd.org but it was not translating to rad social.
Will go with :basketball:  :earth_asia:  :fire: